### PR TITLE
fix: delete redis in application.yml

### DIFF
--- a/src/api/src/main/resources/application.yml
+++ b/src/api/src/main/resources/application.yml
@@ -11,10 +11,6 @@ spring:
     import:
       - application-storage-${spring.profiles.active}.yml
       - application-oauth.yml
-  data:
-    redis:
-      host: 127.0.0.1
-      port: 6379
 security:
   aes128:
     key: 1q2w3e4r5t6y7u8i


### PR DESCRIPTION
## Description
- dns달아놓은 후 dev테스트 목적
- application.yml에 남아있는 redis config 삭제