### PR TITLE
fix: RefreshToken Header 정보 삭제

### DIFF
--- a/src/api/src/main/kotlin/com/tenmm/tilserver/security/adapter/inbound/rest/RefreshTokenController.kt
+++ b/src/api/src/main/kotlin/com/tenmm/tilserver/security/adapter/inbound/rest/RefreshTokenController.kt
@@ -1,11 +1,8 @@
 package com.tenmm.tilserver.security.adapter.inbound.rest
 
-import com.tenmm.tilserver.common.security.annotation.RequiredAuthentication
 import com.tenmm.tilserver.security.adapter.inbound.rest.model.RefreshTokenRequest
 import com.tenmm.tilserver.security.adapter.inbound.rest.model.RefreshTokenResponse
 import com.tenmm.tilserver.security.application.inbound.RefreshTokenUseCase
-import com.tenmm.tilserver.security.domain.SecurityToken
-import com.tenmm.tilserver.security.domain.UserAuthInfo
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,18 +15,14 @@ import org.springframework.web.bind.annotation.RestController
 class RefreshTokenController(
     private val refreshTokenUseCase: RefreshTokenUseCase,
 ) {
-    @RequiredAuthentication
     @PostMapping("/refresh")
     suspend fun refreshToken(
-        userAuthInfo: UserAuthInfo,
         @RequestBody refreshTokenRequest: RefreshTokenRequest,
     ): RefreshTokenResponse {
         val result = refreshTokenUseCase.refresh(
-            SecurityToken(
-                userIdentifier = userAuthInfo.userIdentifier,
-                accessToken = refreshTokenRequest.accessToken,
-                refreshToken = refreshTokenRequest.refreshToken
-            )
+            accessToken = refreshTokenRequest.accessToken,
+            refreshToken = refreshTokenRequest.refreshToken
+
         )
         return RefreshTokenResponse(result.accessToken)
     }

--- a/src/api/src/main/kotlin/com/tenmm/tilserver/security/application/inbound/RefreshTokenUseCase.kt
+++ b/src/api/src/main/kotlin/com/tenmm/tilserver/security/application/inbound/RefreshTokenUseCase.kt
@@ -3,5 +3,5 @@ package com.tenmm.tilserver.security.application.inbound
 import com.tenmm.tilserver.security.domain.SecurityToken
 
 interface RefreshTokenUseCase {
-    suspend fun refresh(securityToken: SecurityToken): SecurityToken
+    suspend fun refresh(accessToken: String, refreshToken: String): SecurityToken
 }

--- a/src/api/src/main/kotlin/com/tenmm/tilserver/security/application/service/RefreshTokenService.kt
+++ b/src/api/src/main/kotlin/com/tenmm/tilserver/security/application/service/RefreshTokenService.kt
@@ -3,9 +3,11 @@ package com.tenmm.tilserver.security.application.service
 import com.tenmm.tilserver.common.domain.UnAuthorizedException
 import com.tenmm.tilserver.security.application.inbound.GenerateTokenUseCase
 import com.tenmm.tilserver.security.application.inbound.RefreshTokenUseCase
+import com.tenmm.tilserver.security.application.inbound.ResolveTokenUseCase
 import com.tenmm.tilserver.security.application.outbound.DeleteRefreshTokenPort
 import com.tenmm.tilserver.security.application.outbound.GetRefreshTokenPort
 import com.tenmm.tilserver.security.domain.SecurityToken
+import com.tenmm.tilserver.security.domain.SecurityTokenType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,10 +16,14 @@ class RefreshTokenService(
     private val getRefreshTokenPort: GetRefreshTokenPort,
     private val deleteRefreshTokenPort: DeleteRefreshTokenPort,
     private val generateTokenUseCase: GenerateTokenUseCase,
+    private val resolveTokenUseCase: ResolveTokenUseCase
 ) : RefreshTokenUseCase {
     @Transactional
-    override suspend fun refresh(securityToken: SecurityToken): SecurityToken {
-        val (userIdentifier, accessToken, refreshToken) = securityToken
+    override suspend fun refresh(accessToken: String, refreshToken: String): SecurityToken {
+        val userIdentifier = resolveTokenUseCase.resolveToken(
+            token = refreshToken,
+            securityTokenType = SecurityTokenType.REFRESH
+        )
         getRefreshTokenPort.getAccessToken(userIdentifier, accessToken, refreshToken)
             ?: throw UnAuthorizedException()
 


### PR DESCRIPTION
## Description
- refreshToken 418떨어지는 것 수정
- Header에 받지않고, RefreshToken에서 Identifer Resolve